### PR TITLE
changing to accept links as text

### DIFF
--- a/chatbot-service/src/main/java/com/ages/incuitech/backend/chatbotservice/api/bot/model/MessageMapper.java
+++ b/chatbot-service/src/main/java/com/ages/incuitech/backend/chatbotservice/api/bot/model/MessageMapper.java
@@ -131,6 +131,7 @@ public class MessageMapper {
     }
 
     private static boolean hasAttachment(Messaging messaging) {
-        return messaging.getMessage().getAttachments() != null && !messaging.getMessage().getAttachments().isEmpty();
+        return messaging.getMessage().getAttachments() != null && !messaging.getMessage().getAttachments().isEmpty() &&
+                messaging.getMessage().getAttachments().get(0).getPayload() != null;
     }
 }


### PR DESCRIPTION
Havia um erro no mapeamento da mensagem do facebook para mensagem interna.
quando um link era enviado, possuindo o banner no facebook
(quando tu coloca um link e ele gera um banner)
Era considero attachment, porem não vinha no payload o campo url, ocasionando num nullpointer

só foi feito o ajuste para que em casos assim, seja considero texto normal